### PR TITLE
Add next error handling for 404 and 500 errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,21 @@ app.use(cookieParser())
 
 routing(app, serviceManager);
 
+// catch 404 and forward to error handler
+app.use(function(req, res, next) {
+  var err = new Error('Not Found');
+  err.status = 404;
+  next(err);
+});
+
+// error handler
+app.use(function(err, req, res) {
+  res.status(err.status || 500);
+  res.render('error', {
+    message: err.message,
+    error: {}
+  });
+});
+
 app.listen(config.port);
 console.log('listening on port: ' + config.port);
-
-


### PR DESCRIPTION
- Add error handling to server.js so that it'll take `next();` errors and forward them on without leaking a stack trace.
- Created 404 error catch that passes 404 onto the error handler.
