### PR TITLE
Static page for highlights

### DIFF
--- a/controllers/staticCtrl.js
+++ b/controllers/staticCtrl.js
@@ -1,0 +1,26 @@
+var express = require('express');
+var swig = require('swig');
+
+module.exports = function(serviceManager) {
+
+	var staticHighlight = function(req, res) {
+		var id = req.params.id;
+
+        var sql = 'SELECT * FROM highlights JOIN events USING (event_id) WHERE highlight_id = $1::int';
+        var query = serviceManager.dbClient.query(sql, [id]);
+
+        query.on('end', function(result) {
+            res.render('highlight', { 
+            	title: result.rows[0].title,
+            	yt: result.rows[0].yt_url,
+            	description: result.rows[0].description
+            });
+        });
+	}
+
+    var router = express.Router();
+
+    router.get('/highlight/:id', staticHighlight);
+
+    return router;
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "body-parser": "~1.12.3",
     "multer": "~0.1.8",
     "nodemailer": "~1.3.4",
-    "cookie-parser": "~1.3.4"
+    "cookie-parser": "~1.3.4",
+    "swig": "~1.4.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/routing.js
+++ b/routing.js
@@ -4,6 +4,7 @@ var eventCtrl = require('./controllers/eventCtrl');
 var contactCtrl = require('./controllers/contactCtrl');
 var suggestionCtrl = require('./controllers/suggestionCtrl');
 var replayCtrl = require('./controllers/replayCtrl');
+var staticCtrl = require('./controllers/staticCtrl');
 
 module.exports = function(app, serviceManager) {
     app.use('/highlight', highlightCtrl(serviceManager));
@@ -12,6 +13,7 @@ module.exports = function(app, serviceManager) {
     app.use('/contact', contactCtrl(serviceManager));
     app.use('/suggestion', suggestionCtrl(serviceManager));
     app.use('/submitreplay', replayCtrl(serviceManager));
+    app.use('/static', staticCtrl(serviceManager));
 
     app.use('/', function(req, res) {
         res.sendStatus(200);

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var swig = require('swig');
 var pg = require('pg');
 var nodemailer = require('nodemailer');
 var bodyParser = require('body-parser');
@@ -51,6 +52,14 @@ app.use(function(err, req, res) {
     error: {}
   });
 });
+
+
+// swig
+app.engine('html', swig.renderFile);
+app.set('view engine', 'html');
+app.set('views', __dirname + '/views');
+app.set('view cache', false);
+swig.setDefaults({ cache: false });
 
 app.listen(config.port);
 console.log('listening on port: ' + config.port);

--- a/views/highlight.html
+++ b/views/highlight.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+<title>{{ title }}</title>
+<meta property="og:title" content="{{ title }}" />
+<meta property="og:site_name" content="Starcraft 2 Highlights"/>
+<meta property="og:description" content="{{ description }}" />
+<meta property="og:image" content="http://img.youtube.com/vi/{{ yt }}/maxresdefault.jpg" />
+</head>
+
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
The static page is only meant for the facebook crawler, therefore it
does not contain any content, but only meta information. The facebook
crawler must be redirected to the static page using mod_rewrite and
mod_proxy.
